### PR TITLE
[BACKEND-717] UnleashClient.isEnabled() returns true on first enabled strategy

### DIFF
--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -72,22 +72,13 @@ class Metrics extends EventDispatcher
             return false;
         }
 
-//        $this->timer = new \EvTimer($this->metricsInterval, 0, function () {
-            $this->sendMetrics();
-//        });
-//
-//        if (getenv('env') !== 'test') {
-//            \Ev::run(\Ev::RUN_NOWAIT);
-//        } else {
-//            \Ev::run();
-//        }
+        $this->sendMetrics();
 
         return true;
     }
 
     public function stop()
     {
-//        \Ev::stop();
         $this->timer = null;
         $this->disabled = true;
     }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -30,7 +30,8 @@ class Repository extends EventDispatcher
         array $headers = [],
         Storage $storageImpl = null,
         Client $client = null
-    ) {
+    )
+    {
         if ($client === null) {
             $this->client = new Client([
                 'base_uri' => $url,
@@ -61,14 +62,7 @@ class Repository extends EventDispatcher
     public function timedFetch()
     {
         if ($this->refreshInterval !== null && $this->refreshInterval > 0) {
-//            $this->timer = new \EvTimer($this->refreshInterval, 0, function () {
-                $this->fetch();
-//            });
-//            if (getenv('env') !== 'test') {
-//                \Ev::run(\Ev::RUN_NOWAIT);
-//            } else {
-//                \Ev::run();
-//            }
+            $this->fetch();
         }
     }
 
@@ -117,7 +111,7 @@ class Repository extends EventDispatcher
         }
 
         return [
-            'version'  => 1,
+            'version' => 1,
             'features' => $features,
         ];
     }
@@ -136,15 +130,15 @@ class Repository extends EventDispatcher
     {
         return [
             'connect_timeout' => $timeout,
-            'headers'         => array_merge(
+            'headers' => array_merge(
                 [
-                    'UNLEASH-APPNAME'    => $this->appName,
+                    'UNLEASH-APPNAME' => $this->appName,
                     'UNLEASH-INSTANCEID' => $this->instanceId,
-                    'User-Agent'         => $this->appName,
+                    'User-Agent' => $this->appName,
                 ],
                 $this->headers
             ),
-            'If-None-match'   => $this->etag,
+            'If-None-match' => $this->etag,
         ];
     }
 }

--- a/src/UnleashClient.php
+++ b/src/UnleashClient.php
@@ -89,7 +89,9 @@ class UnleashClient extends EventDispatcher
                 continue;
             }
 
-            return $strategy->isEnabled($strategySelector->parameters, $context);
+            if  ($strategy->isEnabled($strategySelector->parameters, $context)) {
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
## Goal

port over logic from https://github.com/Unleash/unleash-client-node/blob/master/src/client.ts#L85-L100 -- mainly, if any matched strategy is enabled, return true. currently, only returns the enabled value of the first non-null strategy (e.g. having `[false, true]` would return `false` instead of `true`)

## Reference

- https://getpocket.atlassian.net/browse/BACKEND-717